### PR TITLE
FEAT: update order API interface - support more ord_types and groupId, clientOid parameters

### DIFF
--- a/docs/rest_v2.md
+++ b/docs/rest_v2.md
@@ -30,7 +30,7 @@ Access to MAX Rest API V2
     * [.orders(options)](#RestV2+orders) ⇒ <code>Promise</code>
     * [.order(options)](#RestV2+order) ⇒ <code>Promise</code>
     * [.trades(options)](#RestV2+trades) ⇒ <code>Promise</code>
-    * [.tradesOfOrder(order)](#RestV2+tradesOfOrder) ⇒ <code>Promise</code>
+    * [.tradesOfOrder(options)](#RestV2+tradesOfOrder) ⇒ <code>Promise</code>
     * [.placeOrder(options)](#RestV2+placeOrder) ⇒ <code>Promise</code>
     * [.placeOrders(options)](#RestV2+placeOrders) ⇒ <code>Promise</code>
     * [.cancelOrders(options)](#RestV2+cancelOrders) ⇒ <code>Promise</code>
@@ -256,7 +256,8 @@ Calibrate local time with system time
 | --- | --- | --- | --- |
 | options | <code>Object</code> |  |  |
 | options.market | <code>string</code> |  | unique market id, check markets() for available markets. Ex: 'btctwd' |
-| [options.state] | <code>Array.&lt;String&gt;</code> |  | order state filter, Ex: ['wait', 'convert', 'done', 'cancel'] |
+| [options.state] | <code>Array.&lt;String&gt;</code> |  | order state filter, Ex: ['wait', 'convert', 'done', 'cancel', 'finalizing'] |
+| [options.groupId] | <code>number</code> |  | filter order by group id |
 | [options.limit] | <code>number</code> | <code>3</code> | returned results limit, maximum 100 |
 | [options.page] | <code>number</code> | <code>1</code> | specify the page of paginated results |
 | [options.orderBy] | <code>string</code> | <code>&quot;desc&quot;</code> | order in created time, can be 'desc', 'asc', 'desc_updated_at' or 'asc_updated_at' |
@@ -270,7 +271,8 @@ Calibrate local time with system time
 | Param | Type | Description |
 | --- | --- | --- |
 | options | <code>Object</code> |  |
-| options.id | <code>number</code> | unique order id |
+| [options.id] | <code>number</code> | unique order id |
+| [options.clientOid] | <code>string</code> | user specific order id in RFC 4122 format. only persist for 24 hours, required when order id is not given |
 
 <a name="RestV2+trades"></a>
 
@@ -290,13 +292,15 @@ Calibrate local time with system time
 
 <a name="RestV2+tradesOfOrder"></a>
 
-### restV2.tradesOfOrder(order) ⇒ <code>Promise</code>
+### restV2.tradesOfOrder(options) ⇒ <code>Promise</code>
 **Kind**: instance method of [<code>RestV2</code>](#RestV2)  
 **See**: https://max.maicoin.com/documents/api_list#!/private/getApiV2TradesMyOfOrder  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| order | <code>number</code> | id - unique id of order |
+| options | <code>Object</code> |  |
+| [options.id] | <code>number</code> | unique id of order |
+| [options.clientOid] | <code>string</code> | user specific order id in RFC 4122 format. only persist for 24 hours, required when order id is not given |
 
 <a name="RestV2+placeOrder"></a>
 
@@ -311,7 +315,10 @@ Calibrate local time with system time
 | options.side | <code>string</code> | 'sell' or 'buy' |
 | options.volume | <code>string</code> | total amount to sell/buy, an order could be partially executed |
 | [options.price] | <code>string</code> | price of a unit, required for limit order |
-| [options.ordType] | <code>string</code> | order type, 'limit' or 'market' |
+| [options.stopPrice] | <code>string</code> | price of a unit, required for stop limit & stop market orders |
+| [options.ordType] | <code>string</code> | order type, 'limit', 'market', 'stop_limit', 'stop_market' or 'post_only' |
+| [options.groupId] | <code>number</code> | group id |
+| [options.clientOid] | <code>string</code> | user specific order id in RFC 4122 format. only persist for 24 hours |
 
 <a name="RestV2+placeOrders"></a>
 
@@ -327,7 +334,10 @@ Calibrate local time with system time
 | options.orders[].side | <code>string</code> | 'sell' or 'buy' |
 | options.orders[].volume | <code>string</code> | total amount to sell/buy, an order could be partially executed |
 | [options.orders[].price] | <code>string</code> | price of a unit, required for limit order |
-| [options.orders[].ordType] | <code>string</code> | order type, 'limit' or 'market' |
+| [options.orders[].stopPrice] | <code>string</code> | price of a unit, required for stop limit  & stop market orders |
+| [options.orders[].ordType] | <code>string</code> | order type, 'limit', 'market', 'stop_limit', 'stop_market' or 'post_only' |
+| [options.orders[].clientOid] | <code>string</code> | user specific order id in RFC 4122 format. only persist for 24 hours |
+| [options.groupId] | <code>number</code> | group id of orders |
 
 <a name="RestV2+cancelOrders"></a>
 
@@ -340,6 +350,7 @@ Calibrate local time with system time
 | options | <code>Object</code> |  |
 | [options.market] | <code>string</code> | specify market, ex: 'btctwd'. Cancel all markets if not set. |
 | [options.side] | <code>string</code> | 'sell' or 'buy'. Cancel both sides if not set. |
+| [options.groupId] | <code>number</code> | group id |
 
 <a name="RestV2+cancelOrder"></a>
 
@@ -350,5 +361,6 @@ Calibrate local time with system time
 | Param | Type | Description |
 | --- | --- | --- |
 | options | <code>Object</code> |  |
-| options.id | <code>number</code> | unique order id |
+| [options.id] | <code>number</code> | unique order id |
+| [options.clientOid] | <code>string</code> | user specific order id in RFC 4122 format. only persist for 24 hours, required when order id is not given |
 

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -12,7 +12,10 @@ const SORTING_DIRECTIONS = {
 
 const ORD_TYPES = {
   LIMIT: 'limit',
-  MARKET: 'market'
+  MARKET: 'market',
+  STOP_LIMIT: 'stop_limit',
+  STOP_MARKET: 'stop_market',
+  POST_ONLY: 'post_only'
 }
 
 const DEPOSIT_STATES = {
@@ -47,7 +50,8 @@ const ORDER_STATES = {
   WAIT: 'wait',
   DONE: 'done',
   CONVERT: 'convert',
-  CANCEL: 'cancel'
+  CANCEL: 'cancel',
+  FINALIZING: 'finalizing'
 }
 
 module.exports = { PERIODS, SIDES, SORTING_DIRECTIONS, ORD_TYPES, DEPOSIT_STATES, WITHDRAWAL_STATES, ORDER_STATES }

--- a/lib/transports/rest_v2.js
+++ b/lib/transports/rest_v2.js
@@ -293,7 +293,8 @@ class RestV2 {
   /**
    * @param {Object} options
    * @param {string} options.market - unique market id, check markets() for available markets. Ex: 'btctwd'
-   * @param {String[]} [options.state] - order state filter, Ex: ['wait', 'convert', 'done', 'cancel']
+   * @param {String[]} [options.state] - order state filter, Ex: ['wait', 'convert', 'done', 'cancel', 'finalizing']
+   * @param {number} [options.groupId] - filter order by group id
    * @param {number} [options.limit=3] - returned results limit, maximum 100
    * @param {number} [options.page=1] - specify the page of paginated results
    * @param {string} [options.orderBy=desc] - order in created time, can be 'desc', 'asc', 'desc_updated_at' or 'asc_updated_at'
@@ -308,7 +309,8 @@ class RestV2 {
 
   /**
    * @param {Object} options
-   * @param {number} options.id - unique order id
+   * @param {number} [options.id] - unique order id
+   * @param {string} [options.clientOid] - user specific order id in RFC 4122 format. only persist for 24 hours, required when order id is not given
    *
    * @return {Promise}
    *
@@ -336,14 +338,15 @@ class RestV2 {
   }
 
   /**
-   * @param {number} order id - unique id of order
+   * @param {Object} options
+   * @param {number} [options.id] - unique id of order
+   * @param {string} [options.clientOid] - user specific order id in RFC 4122 format. only persist for 24 hours, required when order id is not given
    *
    * @return {Promise}
    *
    * @see https://max.maicoin.com/documents/api_list#!/private/getApiV2TradesMyOfOrder
    */
-  tradesOfOrder (orderId) {
-    const options = { id: orderId }
+  tradesOfOrder (options) {
     return this._request.getPrivate('/api/v2/trades/my/of_order', options, optionsSchema.orderTrades)
   }
 
@@ -353,7 +356,10 @@ class RestV2 {
    * @param {string} options.side - 'sell' or 'buy'
    * @param {string} options.volume - total amount to sell/buy, an order could be partially executed
    * @param {string} [options.price] - price of a unit, required for limit order
-   * @param {string} [options.ordType] - order type, 'limit' or 'market'
+   * @param {string} [options.stopPrice] - price of a unit, required for stop limit & stop market orders
+   * @param {string} [options.ordType] - order type, 'limit', 'market', 'stop_limit', 'stop_market' or 'post_only'
+   * @param {number} [options.groupId] - group id
+   * @param {string} [options.clientOid] - user specific order id in RFC 4122 format. only persist for 24 hours
    *
    * @return {Promise}
    *
@@ -370,7 +376,10 @@ class RestV2 {
    * @param {string} options.orders[].side - 'sell' or 'buy'
    * @param {string} options.orders[].volume - total amount to sell/buy, an order could be partially executed
    * @param {string} [options.orders[].price] - price of a unit, required for limit order
-   * @param {string} [options.orders[].ordType] - order type, 'limit' or 'market'
+   * @param {string} [options.orders[].stopPrice] - price of a unit, required for stop limit  & stop market orders
+   * @param {string} [options.orders[].ordType] - order type, 'limit', 'market', 'stop_limit', 'stop_market' or 'post_only'
+   * @param {string} [options.orders[].clientOid] - user specific order id in RFC 4122 format. only persist for 24 hours
+   * @param {number} [options.groupId] - group id of orders
    *
    * @return {Promise}
    *
@@ -384,6 +393,7 @@ class RestV2 {
    * @param {Object} options
    * @param {string} [options.market] - specify market, ex: 'btctwd'. Cancel all markets if not set.
    * @param {string} [options.side] - 'sell' or 'buy'. Cancel both sides if not set.
+   * @param {number} [options.groupId] - group id
    *
    * @return {Promise}
    *
@@ -395,7 +405,8 @@ class RestV2 {
 
   /**
    * @param {Object} options
-   * @param {number} options.id - unique order id
+   * @param {number} [options.id] - unique order id
+   * @param {string} [options.clientOid] - user specific order id in RFC 4122 format. only persist for 24 hours, required when order id is not given
    *
    * @return {Promise}
    *

--- a/lib/utils/options_schema.js
+++ b/lib/utils/options_schema.js
@@ -30,7 +30,7 @@ const optionalSideOption = { type: String, enum: sides }
 const volumeOption = { type: String, required: true, use: { decimalStringValidator }, message: `volume ${decimalStringMessage}.` }
 const priceOption = { type: String, use: { decimalStringValidator }, message: `price ${decimalStringMessage}.` }
 const ordTypeOption = { type: String, enum: ordTypes }
-const orderOption = { side: sideOption, volume: volumeOption, price: priceOption, ordType: ordTypeOption }
+const orderOption = { side: sideOption, volume: volumeOption, price: priceOption, stopPrice: priceOption, ordType: ordTypeOption, clientOid: optionalString }
 const depositStateOption = { type: String, enum: depositStates }
 const withdrawalStateOption = { type: String, enum: withdrawalStates }
 const orderStateOption = {
@@ -94,12 +94,14 @@ const optionsSchema = {
   orders: {
     market: requiredString,
     state: orderStateOption,
+    groupId: optionalNumber,
     limit: optionalNumber,
     page: optionalNumber,
     orderBy: sortingOption
   },
   order: {
-    id: requiredNumber
+    id: optionalNumber,
+    clientOid: optionalString
   },
   trades: {
     market: requiredString,
@@ -117,18 +119,24 @@ const optionsSchema = {
     side: sideOption,
     volume: volumeOption,
     price: priceOption,
-    ordType: ordTypeOption
+    stopPrice: priceOption,
+    ordType: ordTypeOption,
+    groupId: optionalNumber,
+    clientOid: optionalString
   },
   placeOrders: {
     market: requiredString,
+    groupId: optionalNumber,
     orders: [orderOption]
   },
   cancelOrders: {
     market: optionalString,
-    side: optionalSideOption
+    side: optionalSideOption,
+    groupId: optionalNumber
   },
   cancelOrder: {
-    id: requiredNumber
+    id: optionalNumber,
+    clientOid: optionalString
   }
 }
 

--- a/lib/utils/options_schema.js
+++ b/lib/utils/options_schema.js
@@ -22,7 +22,6 @@ function periodValidator (val) {
 const requiredString = { type: String, required: true }
 const optionalString = { type: String }
 const optionalNumber = { type: Number }
-const requiredNumber = { type: Number, required: true }
 const sortingOption = { type: String, enum: sortingDirections }
 const periodOption = { type: Number, use: { periodValidator }, message: `period should be a valid number in one of the options: ${periods}.` }
 const sideOption = { type: String, enum: sides, required: true }
@@ -112,7 +111,8 @@ const optionsSchema = {
     orderBy: sortingOption
   },
   orderTrades: {
-    id: requiredNumber
+    id: optionalNumber,
+    clientOid: optionalString
   },
   placeOrder: {
     market: requiredString,


### PR DESCRIPTION
1. Support more ord_types: `stop_limit, stop_market, post_only`
2. Add **groupId** (Integer) & **clientOid** (string - `UUID format`) parameters for order operations
    1. place order with **groupId**
    2. place order with **clientOid**
    3. query orders by **groupId**
    4. query order by **clientOid**
    5. clear orders by **groupId**
    6. cancel order by **clientOid**
3. update rest API documentations
4. **Breaking Change**: `now you need to pass an object to tradesOfOrder method
instead of an integer`

Ticket: https://github.com/maicoin/max-exchange-api-node/projects/1#card-51411533