### PR TITLE
RELEASE v2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+<a name="2.0.0"></a>
+# [2.0.0](https://github.com/maicoin/max-exchange-api-node/compare/v1.2.0...v2.0.0) (2021-03-03)
+
+
+### Chores
+
+* remove old websocket API support ([ed73592](https://github.com/maicoin/max-exchange-api-node/commit/ed73592))
+
+
+### Features
+
+* add more supported ord_types and order states ([7adb045](https://github.com/maicoin/max-exchange-api-node/commit/7adb045))
+* support group_id & client_oid for orders ([aadf0bc](https://github.com/maicoin/max-exchange-api-node/commit/aadf0bc))
+* update tradesOfOrder interface ([342e1e2](https://github.com/maicoin/max-exchange-api-node/commit/342e1e2))
+* support new websocket API ([document](https://maicoin.github.io/max-websocket-docs/))
+
+
+### BREAKING CHANGES
+
+* wss://max-ws.maicoin.com is no longer supported
+* now you need to pass an object to tradesOfOrder method
+instead of an integer
+
+
+
 <a name="1.2.0"></a>
 # [1.2.0](https://github.com/maicoin/max-exchange-api-node/compare/v1.1.0...v1.2.0) (2020-05-06)
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A node.js implementation of MAX exchange API
 
 * [REST API Introduction](https://max.maicoin.com/documents/api_v2)
 * [REST API End Points](https://max.maicoin.com/documents/api_list)
+* [WebSocket API Documentation](https://maicoin.github.io/max-websocket-docs/)
 
 ## Installation
 
@@ -16,7 +17,9 @@ A node.js implementation of MAX exchange API
 npm install max-exchange-api-node
 ```
 
-see `/docs` for MAX and RESTV2 methods.
+see `/docs` for MAX and RESTV2, WebSocketAPI methods.
+
+see `/examples` for WebSocket Usages.
 
 ## Usage
 
@@ -55,4 +58,21 @@ rest.orders({ market: 'maxtwd', state: ['wait', 'convert', 'done'] })
     console.log(error.message)
   })
 })
+```
+
+Example for subscribing orderbook from websocket API
+
+```js
+const ws = max.ws()
+const book = new WebSocketBook(ws, 'btctwd', 10)
+
+book.onUpdate((book) => {
+  book.pretty()
+})
+
+ws.on('error', (errors) => {
+  console.error(errors)
+})
+// ws.on('raw', (body) => console.log(body) )
+ws.connect()
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "max-exchange-api-node",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "max-exchange-api-node",
-  "version": "1.2.0",
+  "version": "2.0.0",
   "description": "Node.js client library for MAX Exchange API",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## Description
Release v2.0.0

## Changelog
### BREAKING CHANGES
* `wss://max-ws.maicoin.com` is no longer supported
* now you need to pass an object to tradesOfOrder method
instead of an integer


### Features
* add more supported ord_types and order states ([7adb045](https://github.com/maicoin/max-exchange-api-node/commit/7adb045))
* support group_id & client_oid for orders ([aadf0bc](https://github.com/maicoin/max-exchange-api-node/commit/aadf0bc))
* update tradesOfOrder interface ([342e1e2](https://github.com/maicoin/max-exchange-api-node/commit/342e1e2))
* support new websocket API ([document](https://maicoin.github.io/max-websocket-docs/))

### Chores
* remove old websocket API support ([ed73592](https://github.com/maicoin/max-exchange-api-node/commit/ed73592))

## Note
Follow the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/) in your repository
### Release Steps
1. checkout release branch, ex: `release/v2.0.0`
2. run `npm run release`
3. push **release** branch & create pull request to **master** branch
4. merge pull request and publish master to npm by `npm publish`